### PR TITLE
Improve PDF viewer toolbar layout on small screens

### DIFF
--- a/assets/pdfjs/web/viewer.css
+++ b/assets/pdfjs/web/viewer.css
@@ -4360,3 +4360,67 @@ dialog :link{
     display:none;
   }
 }
+
+@media all and (max-width: 500px){
+  #toolbarViewer{
+    display:flex;
+    flex-direction:column;
+    align-items:stretch;
+    justify-content:center;
+    gap:4px;
+    height:auto;
+    padding-block:4px;
+  }
+
+  #toolbarViewerLeft,
+  #toolbarViewerMiddle,
+  #toolbarViewerRight{
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    width:100%;
+    float:none;
+  }
+
+  #toolbarViewerLeft{
+    order:1;
+  }
+
+  #toolbarViewerMiddle{
+    order:2;
+    margin:0;
+    left:auto;
+    position:relative;
+    transform:none;
+  }
+
+  #toolbarViewerRight{
+    order:3;
+  }
+
+  #toolbarViewerLeft > *,
+  #toolbarViewerMiddle > *,
+  #toolbarViewerRight > *{
+    float:none;
+  }
+
+  #toolbarViewerMiddle .splitToolbarButton{
+    width:100%;
+    display:flex;
+  }
+
+  #toolbarViewerMiddle .splitToolbarButton > .toolbarButton{
+    flex:1 1 50%;
+    justify-content:center;
+    display:flex;
+    align-items:center;
+    width:100%;
+  }
+
+  #editorModeButtons,
+  #print,
+  #download,
+  #secondaryToolbarToggle{
+    display:none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a 500px mobile breakpoint that reflows the PDF toolbar with flexbox and removes surplus controls
- expand the center split toolbar button to span the full width so zoom controls stay accessible

## Testing
- Manual visual check at 390px viewport (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68de93d5e5cc83228c91fd20e7b014f0