### PR TITLE
Add configurable default viewport for PDF viewer

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,13 @@ const UPLOAD_STORAGE_KEY = "frnight-uploaded-ticket";
 const NOW_OVERRIDE_KEY = "frnight-now-override";
 
 const FALLBACK_PDF = "assets/frnight-placeholder.pdf";
+// left/top waarden zijn CSS-pixels; een grote left (bijv. 9999) scrolt na renderen
+// van de pagina effectief naar de rechterrand in PDF.js.
+const DEFAULT_VIEWPORT = {
+  zoom: "150",
+  left: "9999",
+  top: "0",
+};
 
 const defaultActivities = [
   {
@@ -841,7 +848,20 @@ async function showPdfViewer(pdfUrl, title, activityId = null) {
   const viewerUrl = new URL("assets/pdfjs/web/viewer.html", window.location.href);
   viewerUrl.searchParams.set("file", baseSource);
   if (pageNumbers.length > 0) {
-    viewerUrl.hash = `page=${pageNumbers[0]}`;
+    const hasViewport =
+      typeof DEFAULT_VIEWPORT !== "undefined" &&
+      DEFAULT_VIEWPORT &&
+      typeof DEFAULT_VIEWPORT.zoom !== "undefined";
+
+    if (
+      hasViewport &&
+      typeof DEFAULT_VIEWPORT.left !== "undefined" &&
+      typeof DEFAULT_VIEWPORT.top !== "undefined"
+    ) {
+      viewerUrl.hash = `page=${pageNumbers[0]}&zoom=${DEFAULT_VIEWPORT.zoom},${DEFAULT_VIEWPORT.left},${DEFAULT_VIEWPORT.top}`;
+    } else {
+      viewerUrl.hash = `page=${pageNumbers[0]}`;
+    }
   } else {
     viewerUrl.hash = "";
   }


### PR DESCRIPTION
## Summary
- add a DEFAULT_VIEWPORT configuration with zoom and scroll offsets for PDF.js
- include default viewport in the generated viewer hash when available
- document how CSS-pixel offsets affect PDF.js scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de96f2157483229a66cc117db964c1