### PR TITLE
Avoid resetting viewer page when unchanged

### DIFF
--- a/app.js
+++ b/app.js
@@ -402,6 +402,12 @@ function applyPendingViewerPage() {
 
   const setPage = () => {
     try {
+      const currentPage =
+        typeof app.page === "number" ? app.page : app.pdfViewer?.currentPageNumber;
+      if (currentPage === desiredPage) {
+        viewerContext.pendingPageNumber = null;
+        return;
+      }
       app.page = desiredPage;
       viewerContext.pendingPageNumber = null;
     } catch (error) {


### PR DESCRIPTION
## Summary
- prevent resetting the PDF viewer page when the desired page matches the current page
- keep pending page tracking intact so default viewport offsets persist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb967ac648322941624b78e048026