### PR TITLE
Ensure PDF viewer waits for initialization before applying pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -419,7 +419,7 @@ function applyPendingViewerPage() {
     }
   };
 
-  if (app.pdfViewer?.pagesCount) {
+  if (app.isInitialViewSet && app.pdfViewer?.pagesCount) {
     attemptSetPage();
     return;
   }
@@ -432,7 +432,7 @@ function applyPendingViewerPage() {
     const onceHandler = () => {
       attemptSetPage();
       if (typeof app.eventBus?.off === "function") {
-        app.eventBus.off("initialviewset", onceHandler);
+        app.eventBus.off("documentinit", onceHandler);
         app.eventBus.off("pagesloaded", onceHandler);
       }
       if (app._frnightPendingPageHandler === onceHandler) {
@@ -442,7 +442,7 @@ function applyPendingViewerPage() {
 
     app._frnightPendingPageHandler = onceHandler;
     const onceOptions = { once: true };
-    app.eventBus.on("initialviewset", onceHandler, onceOptions);
+    app.eventBus.on("documentinit", onceHandler, onceOptions);
     app.eventBus.on("pagesloaded", onceHandler, onceOptions);
   }
 }


### PR DESCRIPTION
## Summary
- require both the initial view and page count before immediately applying a pending PDF page
- replace the initial view listener with document initialization, keeping pagesloaded as a fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debf7befb88322977ce0115373cae7