### PR TITLE
Add calendar action to open uploaded PDF in native viewer

### DIFF
--- a/app.js
+++ b/app.js
@@ -1091,12 +1091,52 @@ function setupUploadFlow() {
   });
 }
 
+function setupOriginalFileButton() {
+  const button = document.querySelector("[data-view-original]");
+  if (!(button instanceof HTMLElement)) {
+    return;
+  }
+
+  button.addEventListener("click", () => {
+    const storedTicket = loadStoredTicket();
+    if (!storedTicket) {
+      return;
+    }
+
+    let source = storedTicket.dataUrl || "";
+    if (!source) {
+      return;
+    }
+
+    if (source.startsWith("data:")) {
+      try {
+        source = getObjectUrlForDataUrl(source);
+      } catch (error) {
+        console.error("Kon data-URL niet voorbereiden voor weergave", error);
+        return;
+      }
+    }
+
+    const anchor = document.createElement("a");
+    anchor.href = source;
+    anchor.target = "_blank";
+    anchor.rel = "noopener";
+    anchor.style.display = "none";
+    document.body.append(anchor);
+    anchor.click();
+    window.setTimeout(() => {
+      anchor.remove();
+    }, 0);
+  });
+}
+
 function syncUiState() {
   const storedTicket = loadStoredTicket();
   const hasTicket = Boolean(storedTicket);
   const onboarding = document.querySelector("[data-onboarding]");
   const calendar = document.querySelector("[data-calendar]");
   const calendarTrigger = document.querySelector("[data-calendar-upload]");
+  const viewOriginalButton = document.querySelector("[data-view-original]");
 
   if (lastKnownTicketState !== hasTicket) {
     if (!hasTicket) {
@@ -1116,6 +1156,9 @@ function syncUiState() {
   }
   if (calendarTrigger instanceof HTMLElement) {
     calendarTrigger.hidden = !hasTicket;
+  }
+  if (viewOriginalButton instanceof HTMLElement) {
+    viewOriginalButton.hidden = !hasTicket;
   }
 }
 
@@ -1140,6 +1183,7 @@ document.addEventListener("DOMContentLoaded", () => {
   setupPdfViewer();
   setupOnboardingFlow();
   setupUploadFlow();
+  setupOriginalFileButton();
   syncUiState();
   activateBatBubble();
 

--- a/index.html
+++ b/index.html
@@ -80,12 +80,20 @@
           <div class="calendar__actions">
             <button
               type="button"
-              class="calendar__upload"
+              class="calendar__action-btn calendar__upload"
               data-upload-trigger
               data-calendar-upload
               hidden
             >
               Upload nieuw document
+            </button>
+            <button
+              type="button"
+              class="calendar__action-btn calendar__view-original"
+              data-view-original
+              hidden
+            >
+              Bestand bekijken
             </button>
           </div>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -381,9 +381,11 @@ main {
   margin-top: 1.5rem;
   display: flex;
   justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.calendar__upload {
+.calendar__action-btn {
   padding: 0.4rem 1.05rem;
   border-radius: 999px;
   border: 1px solid rgba(249, 114, 22, 0.5);
@@ -397,8 +399,8 @@ main {
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.calendar__upload:focus-visible,
-.calendar__upload:hover {
+.calendar__action-btn:focus-visible,
+.calendar__action-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 26px rgba(249, 114, 22, 0.28);
   border-color: rgba(249, 114, 22, 0.75);


### PR DESCRIPTION
## Summary
- add a "Bestand bekijken" calendar action button for opening the uploaded PDF
- reuse button styling so multiple actions can sit side-by-side in the calendar footer
- hook up state syncing and click behavior to launch the stored PDF in the device viewer

## Testing
- Manual - Loaded index.html in browser

------
https://chatgpt.com/codex/tasks/task_e_68e03e548a74832286075b36b34bd653