### PR TITLE
Sort wait times by descending duration

### DIFF
--- a/app.js
+++ b/app.js
@@ -1283,10 +1283,10 @@ function setupWaitTimesWidget() {
         if (typeof wait === "number" && Number.isFinite(wait) && wait >= 0) {
           return wait;
         }
-        return Number.POSITIVE_INFINITY;
+        return Number.NEGATIVE_INFINITY;
       };
 
-      const waitDiff = normalizeWait(a) - normalizeWait(b);
+      const waitDiff = normalizeWait(b) - normalizeWait(a);
       if (waitDiff !== 0) {
         return waitDiff;
       }


### PR DESCRIPTION
## Summary
- adjust wait time normalization to treat missing values as the lowest priority
- invert the sort comparison so rides with the longest waits appear first

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e10d8b7a808322ace78974546b3625